### PR TITLE
bug fix of timelines in GUI

### DIFF
--- a/ProjectFiles/src/timelineManager/controller/MainWindowController.java
+++ b/ProjectFiles/src/timelineManager/controller/MainWindowController.java
@@ -198,7 +198,10 @@ public class MainWindowController extends AbstractController implements Initiali
         dateGrid.getColumnConstraints().setAll(new ColumnConstraints(DAY_PIXEL_SIZE,DAY_PIXEL_SIZE,DAY_PIXEL_SIZE));
         dateGrid.getRowConstraints().setAll(new RowConstraints(20,20,20));
         dateGrid.getRowConstraints().add(0, new RowConstraints(40,40,40));
-        
+        timelineGrid.setMaxWidth(950);
+        timelineGrid.setMinWidth(950);
+        timelineScrollPane.setMaxWidth(1005);
+        timelineScrollPane.setMinWidth(1005);
         timelineGrid.getRowConstraints().setAll(new RowConstraints(20,20,20));
         timelineGrid.getColumnConstraints().setAll(new ColumnConstraints(DAY_PIXEL_SIZE,DAY_PIXEL_SIZE,DAY_PIXEL_SIZE));
        

--- a/ProjectFiles/src/timelineManager/helpClasses/TimelineViewer.java
+++ b/ProjectFiles/src/timelineManager/helpClasses/TimelineViewer.java
@@ -43,7 +43,7 @@ public class TimelineViewer
         // Filler for first row to make grid correct size
         for(int i = 0; i < 16; i++)
         {
-            Rectangle rect = new Rectangle(DAY_PIXEL_SIZE-1, 20);
+            Rectangle rect = new Rectangle(DAY_PIXEL_SIZE, 20);
             rect.setVisible(false);
             grid.add(rect, i, 0, 1, 1);
         }


### PR DESCRIPTION
this fixes so the gridpane wount scroll when timelines and tasks stretches out to the right of the screen
also makes the timelines and tasks fit better in the grid according to the date-grid